### PR TITLE
Limit export to Assembly-CSharp.dll

### DIFF
--- a/Il2CppDumper/Outputs/DummyAssemblyExporter.cs
+++ b/Il2CppDumper/Outputs/DummyAssemblyExporter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace Il2CppDumper
 {
@@ -14,9 +15,12 @@ namespace Il2CppDumper
             var dummy = new DummyAssemblyGenerator(il2CppExecutor, addToken);
             foreach (var assembly in dummy.Assemblies)
             {
-                using var stream = new MemoryStream();
-                assembly.Write(stream);
-                File.WriteAllBytes(assembly.MainModule.Name, stream.ToArray());
+                if (assembly.MainModule.Name.Equals("Assembly-CSharp.dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    using var stream = new MemoryStream();
+                    assembly.Write(stream);
+                    File.WriteAllBytes(assembly.MainModule.Name, stream.ToArray());
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- filter dummy assembly export to only write `Assembly-CSharp.dll`

## Testing
- `dotnet build Il2CppDumper.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6872a6d530a083328ae7b1cfbf5ffbec